### PR TITLE
feat/create product list component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import styles from "./App.module.css";
 import BookmarkPage from "./Pages/BookmarkPage";
 import MainPage from "./Pages/MainPage";
@@ -7,10 +8,38 @@ import Footer from "./components/Footer";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
 function App() {
+  const [AllProductData, setAllProductData] = useState([]);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch("http://cozshopping.codestates-seb.link/api/v1/products")
+      .then((res) => res.json())
+      .then((data) => {
+        const sortedData = data.sort((a, b) => a.id - b.id);
+        setAllProductData(sortedData);
+        // console.log(sortedData);
+      })
+      .catch((err) => {
+        // console.dir(err);
+        setError(err.message);
+      });
+  }, []);
+
   return (
     <Router>
       <div className={styles["app-container"]}>
         <Header />
+        <div className="error-message">
+          {error && (
+            <>
+              <p>{error}</p>
+              <p>
+                필요한 상품 데이터를 받아오지 못했습니다. 화면을 새로고침
+                해주세요
+              </p>
+            </>
+          )}
+        </div>
         <Routes>
           <Route path="/" element={<MainPage />} />
           <Route path="/products/list" element={<ProductListPage />} />

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 function App() {
   const [AllProductData, setAllProductData] = useState([]);
   const [error, setError] = useState(null);
+  // console.log(AllProductData);
 
   useEffect(() => {
     fetch("http://cozshopping.codestates-seb.link/api/v1/products")
@@ -41,7 +42,10 @@ function App() {
           )}
         </div>
         <Routes>
-          <Route path="/" element={<MainPage />} />
+          <Route
+            path="/"
+            element={<MainPage AllProductData={AllProductData} />}
+          />
           <Route path="/products/list" element={<ProductListPage />} />
           <Route path="/bookmark" element={<BookmarkPage />} />
         </Routes>

--- a/src/Pages/MainPage.js
+++ b/src/Pages/MainPage.js
@@ -1,17 +1,35 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import ItemList from "../components/ItemList";
 import styles from "./MainPage.module.css";
 
-function MainPage() {
+function MainPage({ AllProductData }) {
+  // 상품 리스트를 위한 4가지 데이터
+  const [fourProductData, setFourProductData] = useState([]);
+  console.log(fourProductData);
+
+  // 북마크 리스트를 위한 4가지 데이터
+
+  const result = [];
+  useEffect(() => {
+    AllProductData.some((el, i) => {
+      result.push(el);
+      if (el.id === 3) {
+        console.log(result);
+        setFourProductData(result);
+        return true;
+      }
+    });
+  }, []);
+
   return (
     <main className={styles["main-container"]}>
       <div>
         <h2>상품 리스트</h2>
-        <ItemList />
+        <ItemList ItemsData={fourProductData} />
       </div>
       <div>
         <h2>북마크 리스트</h2>
-        <ItemList />
+        <ItemList ItemsData={fourProductData} />
       </div>
     </main>
   );

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -56,6 +56,7 @@ const Wrapper = styled.section`
     position: relative;
     left: 105px;
     bottom: ${(props) => (props.type === "Category" ? "65px" : "85px")};
+    cursor: pointer;
   }
 `;
 

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -1,67 +1,67 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Item from "./Item";
 import styles from "./ItemList.module.css";
 
-const mockData = [
-  {
-    id: 22,
-    type: "Product",
-    title: "카페라떼",
-    sub_title: null,
-    brand_name: null,
-    price: "2500",
-    discountPercentage: 50,
-    image_url:
-      "https://images.unsplash.com/photo-1459755486867-b55449bb39ff?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1469&q=80",
-    brand_image_url: null,
-    follower: null,
-  },
-  {
-    id: 62,
-    type: "Category",
-    title: "보드게임",
-    sub_title: null,
-    brand_name: null,
-    price: null,
-    discountPercentage: null,
-    image_url:
-      "https://images.unsplash.com/photo-1632501641765-e568d28b0015?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80",
-    brand_image_url: null,
-    follower: null,
-  },
-  {
-    id: 71,
-    type: "Exhibition",
-    title: "인생샷 핫플레이스",
-    sub_title: "입장권 구매시 기념품 증정",
-    brand_name: null,
-    price: null,
-    discountPercentage: null,
-    image_url:
-      "https://images.pexels.com/photos/3862601/pexels-photo-3862601.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
-    brand_image_url: null,
-    follower: null,
-  },
-  {
-    id: 21,
-    type: "Brand",
-    title: null,
-    sub_title: null,
-    brand_name: "펩시",
-    price: null,
-    discountPercentage: null,
-    image_url: null,
-    brand_image_url:
-      "https://images.unsplash.com/photo-1629203851122-3726ecdf080e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1529&q=80",
-    follower: 3940,
-  },
-];
+// const mockData = [
+//   {
+//     id: 22,
+//     type: "Product",
+//     title: "카페라떼",
+//     sub_title: null,
+//     brand_name: null,
+//     price: "2500",
+//     discountPercentage: 50,
+//     image_url:
+//       "https://images.unsplash.com/photo-1459755486867-b55449bb39ff?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1469&q=80",
+//     brand_image_url: null,
+//     follower: null,
+//   },
+//   {
+//     id: 62,
+//     type: "Category",
+//     title: "보드게임",
+//     sub_title: null,
+//     brand_name: null,
+//     price: null,
+//     discountPercentage: null,
+//     image_url:
+//       "https://images.unsplash.com/photo-1632501641765-e568d28b0015?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80",
+//     brand_image_url: null,
+//     follower: null,
+//   },
+//   {
+//     id: 71,
+//     type: "Exhibition",
+//     title: "인생샷 핫플레이스",
+//     sub_title: "입장권 구매시 기념품 증정",
+//     brand_name: null,
+//     price: null,
+//     discountPercentage: null,
+//     image_url:
+//       "https://images.pexels.com/photos/3862601/pexels-photo-3862601.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+//     brand_image_url: null,
+//     follower: null,
+//   },
+//   {
+//     id: 21,
+//     type: "Brand",
+//     title: null,
+//     sub_title: null,
+//     brand_name: "펩시",
+//     price: null,
+//     discountPercentage: null,
+//     image_url: null,
+//     brand_image_url:
+//       "https://images.unsplash.com/photo-1629203851122-3726ecdf080e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1529&q=80",
+//     follower: 3940,
+//   },
+// ];
 
-function ItemList() {
+function ItemList({ ItemsData }) {
   return (
     <div className={styles["item-list-container"]}>
-      {mockData.map((el, i) => (
-        <Item key={i} dataObj={el} />
+      {ItemsData.map((el, i) => (
+        <Item key={el.id} dataObj={el} />
       ))}
     </div>
   );


### PR DESCRIPTION
- 기능구현
  - 상품 데이터 전체 fetch() 해오기: App 컴포넌트 안에서 백엔드 api에서 fetch 해온 전체 데이터 상품 id순으로 정렬하고 저장하기 -> MainPage에 prop으로 내려보냄
  - MainPage 안의 상품리스트에 상품 앞의 4가지 렌더링

- 추후 구현해야할 사항
  - 상품 데이터를 props로 내려보는게 귀찮아지거나, filter 하고 분류해야할 상황이 많이지면 redux 로 리팩토링 하는것 고려해보기